### PR TITLE
breaking apart replication_controller and deployment

### DIFF
--- a/lib/keel/gcloud/kubernetes.rb
+++ b/lib/keel/gcloud/kubernetes.rb
@@ -1,3 +1,4 @@
 require_relative 'kubernetes/namespace'
 require_relative 'kubernetes/replication_controller'
+require_relative 'kubernetes/deployment'
 require_relative 'kubernetes/pod'

--- a/lib/keel/gcloud/kubernetes/deployment.rb
+++ b/lib/keel/gcloud/kubernetes/deployment.rb
@@ -17,6 +17,18 @@ module Keel::GCloud
                 return false unless rcs_yaml["items"].count > 0
                 self.from_yaml rcs_yaml 
             end
+
+            # 
+            # Create a Deployment and expose it on kubernetes
+            #
+            def self.create app_name, image_path, port, sha, namespace
+                cli            = Cli.new
+                deploy_command = "kubectl run #{app_name} --image=#{image_path}:#{sha} --namespace=#{namespace}"
+                expose_command = "kubectl expose deployment #{app_name} --port=80 --target-port=#{port} --type=LoadBalancer --namespace=#{namespace}"
+                cli.execute(deploy_command)
+                cli.execute(expose_command)
+            end
+      
         end
     end
 end

--- a/lib/keel/gcloud/kubernetes/deployment.rb
+++ b/lib/keel/gcloud/kubernetes/deployment.rb
@@ -1,0 +1,22 @@
+module Keel::GCloud
+    module Kubernetes
+        #
+        # A class to represent a Kubernetes Deployment
+        class Deployment < ReplicationController
+
+            #
+            # Fetches the correct deployment or replication controller from Kubernetes.
+            #
+            # @param env [String] the namespace/environment for which to fetch the controllers
+            # @param app [String] the app for which to fetch the controllers
+            # @return [Hash] the parsed result of the API call
+            #
+            def self.fetch_all env, app
+                command = "kubectl get deployment --namespace=#{env} -l app=#{app} -o yaml"
+                rcs_yaml = YAML.load Cli.new.execute(command)
+                return false unless rcs_yaml["items"].count > 0
+                self.from_yaml rcs_yaml 
+            end
+        end
+    end
+end

--- a/lib/keel/gcloud/kubernetes/replication_controller.rb
+++ b/lib/keel/gcloud/kubernetes/replication_controller.rb
@@ -47,18 +47,10 @@ module Keel::GCloud
       # @return [Hash] the parsed result of the API call
       #
       def self.fetch_all env, app
-        commands   = [
-          "kubectl get rc --namespace=#{env} -l app=#{app} -o yaml",
-          "kubectl get deployment --namespace=#{env} -l run=#{app} -o yaml"
-        ]
-        rcs_yaml = nil
-        for command in commands.each
-          rcs_yaml = YAML.load Cli.new.execute(command)
-          break if rcs_yaml["items"].count > 0  # kubernetes object found!
-        end
-
+        command = "kubectl get rc --namespace=#{env} -l app=#{app} -o yaml"
+        rcs_yaml = YAML.load Cli.new.execute(command)
         return false unless rcs_yaml["items"].count > 0
-        self.from_yaml rcs_yaml
+        self.from_yaml rcs_yaml 
       end
 
       #

--- a/lib/keel/gcloud/kubernetes/replication_controller.rb
+++ b/lib/keel/gcloud/kubernetes/replication_controller.rb
@@ -63,17 +63,6 @@ module Keel::GCloud
         Cli.new.system_call "kubectl replace -f #{file}"
       end
 
-      # 
-      # Create a Deployment and expose it on kubernetes
-      #
-      def self.create app_name, image_path, port, sha, namespace
-        cli            = Cli.new
-        deploy_command = "kubectl run #{app_name} --image=#{image_path}:#{sha} --namespace=#{namespace}"
-        expose_command = "kubectl expose deployment #{app_name} --port=80 --target-port=#{port} --type=LoadBalancer --namespace=#{namespace}"
-        cli.execute(deploy_command)
-        cli.execute(expose_command)
-      end
-      
       #
       # Get the YAML representation of the controller.
       #

--- a/test/keel/gcloud/kubernetes/deployment_test.rb
+++ b/test/keel/gcloud/kubernetes/deployment_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+module Keel::GCloud::Kubernetes
+    class DeploymentTest < Minitest::Test
+        def setup
+            @env = 'foo'
+            @app = 'bar'
+            @empty_kubectl_response = <<-EOS
+apiVersion: v1
+items: []
+kind: List
+metadata: {}
+            EOS
+        end
+
+        def test_that_it_returns_false_if_no_namespaces_are_returned
+            
+            cli = Minitest::Mock.new
+            cli.expect :execute, @empty_kubectl_response, ["kubectl get deployment --namespace=#{@env} -l app=#{@app} -o yaml"]
+
+            Keel::GCloud::Cli.stub :new, cli do
+                assert !Deployment.fetch_all(@env, @app)
+            end
+
+            assert cli.verify
+        end
+    end
+end

--- a/test/keel/gcloud/kubernetes/replication_controller_test.rb
+++ b/test/keel/gcloud/kubernetes/replication_controller_test.rb
@@ -16,7 +16,6 @@ metadata: {}
     def test_that_it_calls_the_get_namespaces_api_for_k8s
       cli = Minitest::Mock.new
       cli.expect :execute, @empty_kubectl_response, ["kubectl get rc --namespace=#{@env} -l app=#{@app} -o yaml"]
-      cli.expect :execute, @empty_kubectl_response, ["kubectl get deployment --namespace=#{@env} -l run=#{@app} -o yaml"]
 
       Keel::GCloud::Cli.stub :new, cli do
         ReplicationController.fetch_all @env, @app
@@ -28,70 +27,12 @@ metadata: {}
     def test_that_it_returns_false_if_no_namespaces_are_returned
       cli = Minitest::Mock.new
       cli.expect :execute, @empty_kubectl_response, ["kubectl get rc --namespace=#{@env} -l app=#{@app} -o yaml"]
-      cli.expect :execute, @empty_kubectl_response, ["kubectl get deployment --namespace=#{@env} -l run=#{@app} -o yaml"]
 
       Keel::GCloud::Cli.stub :new, cli do
         assert !ReplicationController.fetch_all(@env, @app)
       end
 
       assert cli.verify
-    end
-
-    def test_that_it_checks_deployments_if_no_rcs
-      mock_yaml = <<-EOS
-
-apiVersion: v1
-items:
-- apiVersion: extensions/v1beta1
-  kind: Deployment
-  metadata:
-    generation: 44
-    labels:
-      run: test
-    name: test
-    namespace: default
-    resourceVersion: "85195"
-    selfLink: /apis/extensions/v1beta1/namespaces/default/deployments/test
-  spec:
-    replicas: 5
-    selector:
-      matchLabels:
-        run: test
-    strategy:
-      rollingUpdate:
-        maxSurge: 1
-        maxUnavailable: 1
-      type: RollingUpdate
-    template:
-      metadata:
-        creationTimestamp: null
-        labels:
-          run: mixtape
-      spec:
-        containers:
-        - image: gcr.io/test/app:1234
-          imagePullPolicy: IfNotPresent
-          name: mixtape
-          resources: {}
-          terminationMessagePath: /dev/termination-log
-        dnsPolicy: ClusterFirst
-        restartPolicy: Always
-        securityContext: {}
-        terminationGracePeriodSeconds: 30
-kind: List
-metadata: {}
-EOS
-      cli = Minitest::Mock.new
-      cli.expect :execute, @empty_kubectl_response, ["kubectl get rc --namespace=#{@env} -l app=#{@app} -o yaml"]
-      cli.expect :execute, mock_yaml, ["kubectl get deployment --namespace=#{@env} -l run=#{@app} -o yaml"]
-
-      Keel::GCloud::Cli.stub :new, cli do
-        result = ReplicationController.fetch_all(@env, @app)
-        assert_kind_of Array, result
-
-        first = result[0]
-        assert first.name, 'test'
-      end
     end
 
     def test_that_it_returns_an_array_of_namespaces


### PR DESCRIPTION
this way we can test for deployments and do a much easier release
TODO: move the update code out of the task and into the kubernetes object
